### PR TITLE
6 estructurar carpetas del backend

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .vscode/
+.idea/
 .env
 .DS_Store
 Thumbs.db

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import createError from "http-errors";
+import boardRoutes from './routes/boards.routes.js';
+
+const app = express();
+app.disable("x-powered-by");
+
+app.use(express.json());
+
+app.use('/api/boards', boardRoutes);
+
+
+app.use((req, res, next) => {
+  if (!req.url.startsWith('/api')) {
+    return res.status(404).send('Ruta no válida');
+  }
+  next(createError(404));
+});
+
+app.use((err, req, res, next) => {
+  if (req.url.startsWith('/api')) {
+    res.status(err.status || 500).json({ error: err.message });
+  } else {
+    res.status(err.status || 500).send('Error del servidor');
+  }
+});
+
+
+export default app;

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,0 +1,4 @@
+import { PrismaClient } from "@prisma/client";
+
+const pool = new PrismaClient();
+export default pool;

--- a/server/controllers/boardController.js
+++ b/server/controllers/boardController.js
@@ -1,0 +1,16 @@
+import BoardModel from "../models/BoardModel.js";
+
+export class BoardController {
+     constructor(boardService) {
+        this.boardService = boardService;
+    }
+    
+    getAll = async (req, res) => {
+        try {
+            const boards = await this.boardService.getAllBoards();
+            res.json(boards);
+        } catch (err) {
+            res.status(500).send('Error al obtener los tableros');
+        }
+    };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,31 +1,7 @@
-import express from "express";
-import { PrismaClient } from "@prisma/client";
+import app from './app.js';
 
-const app = express();
-const prisma = new PrismaClient();
+const PORT = process.env.PORT || 3000;
 
-app.get("/", (req, res) => {
-  console.log("Esta versión del servidor está corriendo muy bien");
-  res.send("Hola mundo desde ESM hola");
-});
-
-app.get("/db", async (req, res) => {
-  try {
-    const boards = await prisma.board.findMany({
-      include: {
-        lists: true,
-        members: {
-          include: { user: true },
-        },
-      },
-    });
-    res.json(boards);
-  } catch (err) {
-    console.log(err)
-    res.status(500).send("Error al conectar a la base de datos");
-  }
-});
-
-app.listen(3000, () => {
-  console.log("Servidor escuchando en http://localhost:3000");
+app.listen(PORT, () => {
+  console.log(`Servidor escuchando en http://localhost:${PORT}`);
 });

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -1,8 +1,6 @@
-import { PrismaClient } from "@prisma/client";
+import prisma from './config/db.js';
 import bcrypt from "bcrypt";
 import readline from "readline";
-
-const prisma = new PrismaClient();
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/server/models/BoardModel.js
+++ b/server/models/BoardModel.js
@@ -1,5 +1,3 @@
-import pool from '../config/db.js';
-
 class BoardModel {
 
      constructor(prisma) {

--- a/server/models/BoardModel.js
+++ b/server/models/BoardModel.js
@@ -1,0 +1,19 @@
+import pool from '../config/db.js';
+
+class BoardModel {
+
+     constructor(prisma) {
+        this.prisma = prisma;
+    }
+
+    async getAll() {
+        return this.prisma.board.findMany({
+            include: {
+                lists: true,
+                members: { include: { user: true } },
+            },
+        });
+    }
+}
+
+export default BoardModel

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
         "express": "^5.1.0",
+        "http-errors": "^2.0.0",
         "pg": "^8.16.3"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^6.12.0",
     "bcrypt": "^6.0.0",
     "express": "^5.1.0",
+    "http-errors": "^2.0.0",
     "pg": "^8.16.3"
   },
   "devDependencies": {

--- a/server/routes/boards.routes.js
+++ b/server/routes/boards.routes.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import prisma from '../config/db.js';
+import BoardModel from '../models/BoardModel.js';
+import BoardService from '../services/BoardService.js';
+import { BoardController } from "../controllers/boardController.js";
+
+const router = Router();
+
+
+// Inyección de dependencias
+const model = new BoardModel(prisma);
+const service = new BoardService(model);
+const controller = new BoardController(service);
+
+router.get(
+  "/",
+  controller.getAll
+);
+
+export default router;

--- a/server/services/BoardService.js
+++ b/server/services/BoardService.js
@@ -1,0 +1,11 @@
+class BoardService {
+  constructor(boardModel) {
+    this.boardModel = boardModel;
+  }
+
+  async getAllBoards() {
+    return this.boardModel.getAll();
+  }
+}
+
+export default BoardService;


### PR DESCRIPTION
Refactor backend para aplicar arquitectura desacoplada por capas

- Separación completa en capas: controller, service, model, routes, config
- Desacoplamiento de Prisma: el ORM queda encapsulado en los modelos
- Inyección de dependencias explícita para mejorar testabilidad y extensibilidad
- Preparado para sustituir Prisma por otro ORM sin afectar capas superiores
- Manejo centralizado de errores y rutas no-API

Estructura lista para escalar y mantener según principios SOLID y buenas prácticas de diseño